### PR TITLE
Settings: Pass Locale.US when formatting refresh rate string

### DIFF
--- a/src/com/android/settings/display/MinRefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/MinRefreshRatePreferenceController.java
@@ -31,6 +31,7 @@ import com.android.settings.core.BasePreferenceController;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class MinRefreshRatePreferenceController extends BasePreferenceController implements
         Preference.OnPreferenceChangeListener {
@@ -66,8 +67,8 @@ public class MinRefreshRatePreferenceController extends BasePreferenceController
             if (m.getPhysicalWidth() == mode.getPhysicalWidth() &&
                     m.getPhysicalHeight() == mode.getPhysicalHeight()) {
                 entries.add(String.format("%.02fHz", m.getRefreshRate())
-                        .replace(".00", ""));
-                values.add(String.format("%.02f", m.getRefreshRate()));
+                        .replaceAll("[\\.,]00", ""));
+                values.add(String.format(Locale.US, "%.02f", m.getRefreshRate()));
             }
         }
         mListPreference.setEntries(entries.toArray(new String[entries.size()]));
@@ -80,7 +81,8 @@ public class MinRefreshRatePreferenceController extends BasePreferenceController
     public void updateState(Preference preference) {
         final float currentValue = Settings.System.getFloat(mContext.getContentResolver(),
                 MIN_REFRESH_RATE, 60.00f);
-        int index = mListPreference.findIndexOfValue(String.format("%.02f", currentValue));
+        int index = mListPreference.findIndexOfValue(
+                String.format(Locale.US, "%.02f", currentValue));
         if (index < 0) index = 0;
         mListPreference.setValueIndex(index);
         mListPreference.setSummary(mListPreference.getEntries()[index]);


### PR DESCRIPTION
* Some locales use comma rather than dot for floating point numbers
  thus causing NumberFormatException when trying to convert string
  to float.
* Also make sure to strip `,00` too when needed.

Change-Id: I57d5606858587daf316194c87ece8b5e30423575